### PR TITLE
expose settings/config via sessionstorage

### DIFF
--- a/src/js/thirdcan.js
+++ b/src/js/thirdcan.js
@@ -1,6 +1,5 @@
-const ttcSettings = fetch(browser.runtime.getURL("injected/default_settings.json"))
+fetch(browser.runtime.getURL("injected/default_settings.json"))
     .then((response) => response.json())
-    .then((settings) => browser.storage.sync.get(settings));
-ttcSettings.then((cfg) => {
-  window.localStorage.setItem("cfg", JSON.stringify(cfg));
-});
+    .then((settings) => browser.storage.sync.get(settings))
+    .then((settings) => JSON.stringify(settings))
+    .then((state) => window.sessionStorage.setItem("ttcConfigState", state));

--- a/src/js/thirdcan.js
+++ b/src/js/thirdcan.js
@@ -1,6 +1,6 @@
-const settings = fetch(browser.runtime.getURL("injected/default_settings.json"))
+const ttcSettings = fetch(browser.runtime.getURL("injected/default_settings.json"))
     .then((response) => response.json())
     .then((settings) => browser.storage.sync.get(settings));
-settings.then((cfg) => {
+ttcSettings.then((cfg) => {
   window.localStorage.setItem("cfg", JSON.stringify(cfg));
 });

--- a/src/js/thirdcan.js
+++ b/src/js/thirdcan.js
@@ -1,0 +1,6 @@
+const settings = fetch(browser.runtime.getURL("injected/default_settings.json"))
+    .then((response) => response.json())
+    .then((settings) => browser.storage.sync.get(settings));
+settings.then((cfg) => {
+  window.localStorage.setItem("cfg", JSON.stringify(cfg));
+});


### PR DESCRIPTION
This PR exposes the user's current settings/configuration through localStorage, which allows injected scripts to read what features the user enabled.

This would be useful in #3/#1 where the "skip for now" button should also confirm skipping the question for now if the user has skip confirmation enabled. It also allows the `textSkipConfirm.js` and `alwaysSkipConfirm.js` scripts to be combined in one file.