### PR TITLE
implement getUserIDFromAnswerPage

### DIFF
--- a/src/injected/skipForNowButton.js
+++ b/src/injected/skipForNowButton.js
@@ -7,7 +7,7 @@
   buttonArea.insertBefore(skipForNowButton, purpleButton.nextSibling);
 
   // hacky way to get user id
-  let userID = await third.GetUserID();
+  let userID = third.GetUserIDFromAnswerPage();
   userID = Number(userID);
 
   function shouldSkip() {

--- a/src/resource/third.js
+++ b/src/resource/third.js
@@ -39,7 +39,7 @@ third.GetSettings = function() {
 
 /**
  * Gets the ID of the current user.
- * @returns {Promise}
+ * @returns {Promise<string>}
  */
 third.GetUserID = function() {
   return new Promise((resolve, reject) => {
@@ -56,6 +56,17 @@ third.GetUserID = function() {
       resolve(html);
     });
   });
+}
+
+/**
+ * Gets the ID of the current user directly from the page if the current page
+ * is "/answer".
+ * @returns {string}
+ */
+third.GetUserIDFromAnswerPage = function() {
+  const attr = document.querySelector("body").getAttribute("onload");
+  const userID = attr.substring(18, attr.length - 1);
+  return userID;
 }
 
 /**


### PR DESCRIPTION
The `GetUserID` method is a hacky way to get the user ID since it calls `TC.Legacy.getPage("/answer")` to fetch the answer page and scrape the user ID from there. It should be used when the user ID is not stored anywhere in the page (e.g. "/savedquestions").

This adds a new method `GetUserIDFromAnswerPage` which should be used in the answer page.