### PR TITLE
Add forum appearance restoration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Chrome: [Chrome Web Store](https://chrome.google.com/webstore/detail/the-third-c
 - Pronouns
 - Temporarily skip questions with the old Skip for Now button
 - Hotkeys for common actions on the answer page
+- Get the old forum homepage back with the "users online" indicator still intact
 
 ## Installation From Source
 If you would like to install the development version of The Third Can for testing purposes, then download or clone this repository, and then follow these instructions, depending on your browser.
@@ -20,7 +21,7 @@ If you would like to install the development version of The Third Can for testin
 1. Go to `about:debugging#/runtime/this-firefox` in the URL bar
 2. Select "Load Temporary Add-on..."
 3. Select the `manifest.json` file
-### Chrome 
+### Chrome
 1. Go to `chrome://extensions/` in the URL bar
 2. Turn on "Developer mode" in the upper-right-hand corner
 3. Create a zip archive of the src/ directory

--- a/docs/third_fourth.md
+++ b/docs/third_fourth.md
@@ -12,7 +12,7 @@ Fourth is much easier to access -- in fact, any script injected via `third.Injec
 ## Third API
 `third.GetPath(path)`: Returns the URL injected script (any script in the `src/injected/` directory, given its location in said directory. Not usually useful to simple features.
 
-`async third.InjectFourth(caller)`: Injects `fourth` into the DOM so that injected scripts can access it. Pass in the name of the file that it's being called from (sans .js) so that it can adjust the methods to the relevant page (e.g. in `src/js/answer.js`, `caller` should be `"answer"` so it can inject a different implementation of `fourth.UserId()` specific to the answer page). 
+`async third.InjectFourth(caller)`: Injects `fourth` into the DOM so that injected scripts can access it. Pass in the name of the file that it's being called from (sans .js) so that it can adjust the methods to the relevant page (e.g. in `src/js/answer.js`, `caller` should be `"answer"` so it can inject a different implementation of `fourth.UserId()` specific to the answer page).
 
 `async third.InjectScript(path, options)`: Injects the script at `third.GetPath(path)` into the page. `options` is an object specifying additional features of the script. Currently, the only option is `noAsync`, which is `false` by default and disables `async` on the code block. Returns the `<script>` element that was created.
 
@@ -28,6 +28,30 @@ Fourth is much easier to access -- in fact, any script injected via `third.Injec
 
 `third.GetUserIDFromAnswerPage()` Returns the user ID, assuming that it is called while on https://twocansandstring.com/answer
 
+### Third Injections
+Injections using third can be performed with one of two functions: `InjectScript` and `InjectToggleableScripts`. The latter acts as a wrapper for the former, letting you inject scripts conditionally based on whether or not a setting is a specific value or not. In most cases `InjectToggleableScripts` is preferred. With these functions you can pass in options for each script, which support the following fields:
+
+Field | Type | Description
+--- | --- | ---
+`useHead` | `boolean` | If set to true, the script will be inserted inside of the document's `head` tag; otherwise, it will be inserted inside of `body`.
+`noAsync` | `boolean` | By default, scripts injected are asynchronous. Setting this to true removes the boolean attribute in the script element, disabling asynchronicity inside of the respective script.
+`defer` | `boolean` | Adds a `defer` boolean attribute to the script element if set to true. You can read about what this does [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#defer).
+
+The syntax of `InjectToggleableScripts` can look like this:
+
+```js
+third.InjectToggleableScripts({
+  anotherSetting: "injectedScript.js",
+  configurationSetting: { name: "injectedScriptTwo.js", useHead: true },
+  yetAnotherSetting: [
+    { name: "injectedScriptThree.js", defer: true },
+    { name: "injectedScriptFour.js", noAsync: true }
+  ]
+}, "caller");
+```
+
+The first argument is an object where each key is the configuration option that controls whether the script is to be injected or not. **If the key's value is a string**, the script encased in strings is injected if the respective configuration option is enabled (injected scripts are in /src/injected/). **If the key's value is an object**, it acts the same as if it were a string, but it also takes into account any extra options passed alongside the `name` parameter. Finally, **if the key's value is an array**, it acts the same as if it were an object, but injects multiple of these scripts at once as part of the same setting.
+
 ## Fourth API
 
 `fourth.enums` A promise that, when resolved, holds the enums object (defined in `src/resource/enums.js`)
@@ -35,3 +59,49 @@ Fourth is much easier to access -- in fact, any script injected via `third.Injec
 `fourth.config()` A function which returns the stored configuration.
 
 `fourth.UserId()` Returns the user's ID number.
+
+### TCaS API Functions
+
+`fourth.Request(fn)` Send a request to the Two Cans and String stitchservices API where `fn` is the name of a specific function following the format of [category].[function].
+
+`fourth.GetUserToken()` Get the user's token if they are logged in if authentication is required. Should be used sparingly.
+
+### Utility Functions
+
+#### `fourth.Alert(title, content, buttons)`
+Opens a popup box with optional buttons. **This returns a promise**, so if you are going to use it you must wait for the user to make an input before continuing further. Examples are shown below if you are confused. `buttons` is an array of JSON objects containing button data. Valid fields are:
+
+Field | Type | Description | Example
+--- | --- | --- | ---
+`text` | `string` | The button's contents. Can contain HTML.
+`color` | `string[]` | An array of two strings to use as the button's color. The color is a linear gradient, and the two elements of the array represent the stops. | `["#a00", "#800"]`
+`callback` | `() => any` | A function to be called when the button is clicked. Any value returned is used to resolve the alert's promise. | `() => true`
+
+The alert box has a close button on the top right. Clicking this causes the promise to return `false`.
+
+An example of how to use this is as follows:
+
+```js
+fourth.Alert(
+  "Important question",
+  "Which food is better?",
+  [
+    {
+      text: "Waffles",
+      callback: () => "w"
+    },
+    {
+      text: "Pancakes",
+      callback: () => "p"
+    }
+  ]
+).then(result => {
+  if (result === "w") {
+    fourth.Alert("Result", "Good."); // Buttons are optional.
+  } else {
+    fourth.Alert("Result", "Not good >:(.");
+  }
+})
+```
+
+`fourth.Confirm(title, content)` Creates an alert (see above) containing two buttons, one labeled "Yes" (returning `true`) and the other labeled "No" (returning `false`).

--- a/src/injected/default_settings.json
+++ b/src/injected/default_settings.json
@@ -4,5 +4,6 @@
   "skipSavedQuestions": true,
   "showPronouns": true,
   "displayLatex": true,
-  "useHotkeys" : false
+  "useHotkeys" : false,
+  "restoreForum" : true
 }

--- a/src/injected/restoreForum.js
+++ b/src/injected/restoreForum.js
@@ -1,0 +1,75 @@
+{
+  function addStyleSheet(dir) {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.type = "text/css";
+    link.href = "/twocans_prod_2022_11_11_21_55_52/res/" + dir + ".css";
+    document.head.appendChild(link);
+  }
+  function getCategories() {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open("POST", "https://twocansandstring.com/stitchservices");
+      xhr.setRequestHeader("Content-Type", "application/json");
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) resolve(JSON.parse(xhr.responseText).responses[0].categories);
+        else reject({
+          status: xhr.status,
+          statusText: xhr.statusText
+        });
+      };
+      xhr.onerror = () => {
+        reject({
+          status: xhr.status,
+          statusText: xhr.statusText
+        });
+      }
+      xhr.send(JSON.stringify({
+        "apiVersion": null,
+        "expectUserChange": true,
+        "requests": [{"fn": "forum.categories"}]
+      }));
+    })
+  }
+  /** @returns {HTMLElement} */
+  const getElementByClass = classname => document.querySelector("." + classname);
+  const delay = ms => new Promise((resolve) => {
+      setTimeout(resolve, ms);
+  });
+
+  (async () => {
+    //// We need to set a delay after the window loads because TCaS's JavaScript overwrites page content before
+    //// we can fully modify it.
+    await delay(10); // This should be enough. Hopefully.
+    document.title = "Two Cans and String : Forum";
+    const categories = await getCategories();
+    //// We need to link the appropriate stylesheets
+    addStyleSheet("common_twocans")
+    addStyleSheet("forum_category");
+    //// Get the page at /things/ to use as a template
+    const r = await fetch("https://twocansandstring.com/forum/things");
+    const body = (new DOMParser()).parseFromString(await r.text(), "text/html");
+    document.body.innerHTML = body.body.innerHTML;
+    document.getElementById("dark_nav").innerHTML = "Forum";
+    // Add search link
+    const a = document.createElement("div");
+    a.innerHTML = '<a href="https://twocansandstring.com/forum/search">Search Posts</a> | <a href="javascript:void(0)">Mark all posts as read</a>';
+    a.style.textAlign = "right";
+    document.getElementById("content_host").prepend(a);
+    //// Now start reconstructing our categories from scratch
+    getElementByClass("forum_threads_table").innerHTML = '<div class="forum_threads_header" style="background:#0000;color:#000;"><div class="titlecol">&nbsp;</div><div class="viewscol">&nbsp;</div><div class="viewscol">Threads</div><div class="repliescol">Posts</div>';
+    for (let category of categories) {
+      const unreadIndicator = category.newThreads ? `<span style="font-weight:bold;color:#53a46e;font-size:10pt;">${category.newThreads} New</span>` : ""
+      const div = document.createElement("div");
+      div.className = "forum_threads_thread";
+      div.innerHTML = `<div class="titlecol">
+<div class="thread_title"><a href="/forum/${category.id}" style="font-weight:bold;">${category.name}</a></div>
+<div class="thread_preview_text">${category.description}</div>
+</div>
+<div class="viewscol">${unreadIndicator}</div>
+<div class="viewscol">${category.threads}</div>
+<div class="repliescol">${category.posts}</div>`
+      getElementByClass("forum_threads_table").appendChild(div);
+    }
+  })();
+}

--- a/src/injected/restoreForum.js
+++ b/src/injected/restoreForum.js
@@ -54,11 +54,10 @@
     //// Finally, construct the "users online" footer
     const usersOnlineDiv = document.createElement("div");
     usersOnlineDiv.id = "forum_main_usersonline"
-    usersOnlineDiv.style = "display:flex;align-items:center;";
     usersOnlineDiv.innerHTML = "Users on the forum:"
     for (let userId in usersOnline) {
       const user = usersOnline[userId];
-      usersOnlineDiv.innerHTML += `&nbsp;<img class="users_online_avatar" style="width:32px;margin-right:4px;" src="${user.avatar}"><a href="/users/${user.key}">${user.name}</a>`;
+      usersOnlineDiv.innerHTML += ` <img class="users_online_avatar" style="width:32px;vertical-align:middle;" src="${user.avatar}"> <a href="/users/${user.key}">${user.name}</a>`;
       if (userId < usersOnline.length - 1) usersOnlineDiv.innerHTML += ",";
     }
     document.getElementById("content_host").appendChild(usersOnlineDiv);

--- a/src/injected/restoreForum.js
+++ b/src/injected/restoreForum.js
@@ -6,31 +6,6 @@
     link.href = "/twocans_prod_2022_11_11_21_55_52/res/" + dir + ".css";
     document.head.appendChild(link);
   }
-  // function getCategories() {
-  //   return new Promise((resolve, reject) => {
-  //     const xhr = new XMLHttpRequest();
-  //     xhr.open("POST", "https://twocansandstring.com/stitchservices");
-  //     xhr.setRequestHeader("Content-Type", "application/json");
-  //     xhr.onload = () => {
-  //       if (xhr.status >= 200 && xhr.status < 300) resolve(JSON.parse(xhr.responseText).responses[0].categories);
-  //       else reject({
-  //         status: xhr.status,
-  //         statusText: xhr.statusText
-  //       });
-  //     };
-  //     xhr.onerror = () => {
-  //       reject({
-  //         status: xhr.status,
-  //         statusText: xhr.statusText
-  //       });
-  //     }
-  //     xhr.send(JSON.stringify({
-  //       "apiVersion": null,
-  //       "expectUserChange": true,
-  //       "requests": [{"fn": "forum.categories"}]
-  //     }));
-  //   })
-  // }
   /** @returns {HTMLElement} */
   const getElementByClass = classname => document.querySelector("." + classname);
   const delay = ms => new Promise((resolve) => {

--- a/src/injected/restoreForum.js
+++ b/src/injected/restoreForum.js
@@ -78,11 +78,12 @@
 
     //// Finally, construct the "users online" footer
     const usersOnlineDiv = document.createElement("div");
+    usersOnlineDiv.id = "forum_main_usersonline"
     usersOnlineDiv.style = "display:flex;align-items:center;";
     usersOnlineDiv.innerHTML = "Users on the forum:"
     for (let userId in usersOnline) {
       const user = usersOnline[userId];
-      usersOnlineDiv.innerHTML += `&nbsp;<img style="width:32px;margin-right:4px;" src="${user.avatar}"><a href="/users/${user.key}">${user.name}</a>`;
+      usersOnlineDiv.innerHTML += `&nbsp;<img class="users_online_avatar" style="width:32px;margin-right:4px;" src="${user.avatar}"><a href="/users/${user.key}">${user.name}</a>`;
       if (userId < usersOnline.length - 1) usersOnlineDiv.innerHTML += ",";
     }
     document.getElementById("content_host").appendChild(usersOnlineDiv);

--- a/src/injected/restoreForum.js
+++ b/src/injected/restoreForum.js
@@ -53,7 +53,7 @@
     document.getElementById("dark_nav").innerHTML = "Forum";
     // Add search link
     const a = document.createElement("div");
-    a.innerHTML = '<a href="https://twocansandstring.com/forum/search">Search Posts</a> | <a href="javascript:void(0)">Mark all posts as read</a>';
+    a.innerHTML = '<a href="https://twocansandstring.com/forum/search">Search Posts</a> | <a href="https://twocansandstring.com/forum/readall">Mark all posts as read</a>';
     a.style.textAlign = "right";
     document.getElementById("content_host").prepend(a);
     //// Now start reconstructing our categories from scratch

--- a/src/injected/skipConfirm.js
+++ b/src/injected/skipConfirm.js
@@ -4,8 +4,8 @@
   const always = cfg.skipConfirm === enums.skipConfirm.ALWAYS;
   let button = document.querySelector("button.purple");
   let textbox = document.getElementById("answer_text");
-  button.onclick = () => {
-    if ((textbox.value === "" && !always) || confirm("Are you sure you want to skip this question?")) {
+  button.onclick = async () => {
+    if ((textbox.value === "" && !always) || await fourth.Confirm("Confirm", "Are you sure you want to skip this question?")) {
       TC.QA.Answer.skip_this(true);
     }
   };

--- a/src/injected/skipForNowButton.js
+++ b/src/injected/skipForNowButton.js
@@ -13,7 +13,7 @@
       // check if user enabled skip confirmation. if so, prompt for confirmation
       // if necessary according to the user's settings
       if ((cfg.skipConfirm === enums.skipConfirm.WHEN_TEXT_IN_BOX && textbox.value !== "") || cfg.skipConfirm === enums.skipConfirm.ALWAYS) {
-        return confirm("Are you sure you want to skip this question for now?");
+        return (await fourth.Confirm("Confirm", "Are you sure you want to skip this question for now?"));
       }
     }
     return true;

--- a/src/injected/skipSavedQuestionButton.js
+++ b/src/injected/skipSavedQuestionButton.js
@@ -13,10 +13,10 @@
       button.classList.add("red");
       button.style.marginRight = "8px";
       button.style.width = "2em";
-      button.onclick = () => {
+      button.onclick = async () => {
         let shouldSkip = true;
         if (cfg.skipConfirm ?? 0 > 0) {
-          shouldSkip = confirm("Are you sure you want to skip this question for now?");
+          shouldSkip = await fourth.Confirm("Confirm", "Are you sure you want to skip this question for now?");
         }
         if (shouldSkip) {
           fetch(`https://twocansandstring.com/api/answer/${id}/skip/${question}/1/0`);

--- a/src/js/forum-home.js
+++ b/src/js/forum-home.js
@@ -1,0 +1,7 @@
+(async() => {
+  const src = browser.runtime.getURL("resource/third.js");
+  const third = (await import(src)).default;
+  third.InjectToggleableScripts({
+    restoreForum: {name: "restoreForum.js", useHead: true, defer: true}
+  }, "forum-home");
+})();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,6 +44,10 @@
       "js": ["/js/browser-polyfill.min.js", "js/forum.js"]
     },
     {
+      "matches": ["*://twocansandstring.com/forum"],
+      "js": ["/js/browser-polyfill.min.js", "js/forum-home.js"]
+    },
+    {
       "matches": ["*://twocansandstring.com/savedquestions"],
       "js": ["/js/browser-polyfill.min.js", "js/savedquestions.js"]
     }

--- a/src/popup/config.html
+++ b/src/popup/config.html
@@ -46,6 +46,9 @@
     <br />
     <input id="displayLatex" type="checkbox" name="displayLatex">
     <label for="displayLatex">Render LaTeX equations in the forum</label>
+    <br />
+    <input type="checkbox" id="restoreForum">
+    <label for="restoreForum">Restore old forum look</label>
     <hr />
     <button id="submit">Save Settings</button>
   </div>

--- a/src/popup/config.js
+++ b/src/popup/config.js
@@ -9,6 +9,7 @@ const tags = {
     "showPronouns",
     "displayLatex",
     "useHotkeys",
+    "restoreForum"
   ],
   radioTags: [
     "skipConfirm",

--- a/src/resource/fourth-api.js
+++ b/src/resource/fourth-api.js
@@ -1,0 +1,56 @@
+////////////////////////////////////////
+// Fourth TCaS API-related functions. //
+////////////////////////////////////////
+
+/**
+ * Send a request to the Two Cans and String stitchservices API.
+ * @param {string} fn The name of the function. Follows the format of [category].[function]. The API is undocumented, so if there is a function name you are looking for that you don't know the name of, then you are mostly out of luck.
+ * @example fourth.Request("forum.categories");
+ */
+fourth.Request = async function(fn) {
+  if (typeof fn === "string") fn = [fn];
+  let fns = [];
+  for (let f of fn) {
+    fns.push({"fn": f});
+  }
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", "https://twocansandstring.com/stitchservices");
+    xhr.setRequestHeader("Content-Type", "application/json");
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) resolve(JSON.parse(xhr.responseText));
+      else reject({
+        status: xhr.status,
+        statusText: xhr.statusText
+      });
+    };
+    xhr.onerror = () => {
+      reject({
+        status: xhr.status,
+        statusText: xhr.statusText
+      });
+    }
+    xhr.send(JSON.stringify({
+      "apiVersion": null,
+      "expectUserChange": true,
+      "requests": fns
+    }));
+  })
+}
+
+/**
+ * This function gets the authentication token of the currently logged in user.
+ * This can be used to perform *just about any request* on their behalf.
+ * Use with caution and only when absolutely necessary.
+ * @returns {string}
+ */
+fourth.GetUserToken = function() {
+  // Generally the only cookie being stored is our auth token. This makes things a bit easier.
+  const c = (`; ${document.cookie}`).split("; twocansandstring_com_auth2=");
+  if (c.length !== 2) {
+    console.warn("The user is not logged in or some sort of error has occurred while fetching twocansandstring_com_auth2. Any functions relying on their authentication token will either not work or have impaired functionality.");
+    return "";
+  }
+  return c.pop().split(";").shift();
+  // Solution sourced from Stack Overflow https://stackoverflow.com/a/15724300
+}

--- a/src/resource/fourth-api.js
+++ b/src/resource/fourth-api.js
@@ -7,35 +7,27 @@
  * @param {string} fn The name of the function. Follows the format of [category].[function]. The API is undocumented, so if there is a function name you are looking for that you don't know the name of, then you are mostly out of luck.
  * @example fourth.Request("forum.categories");
  */
-fourth.Request = async function(fn) {
+fourth.Request = function(fn) {
   if (typeof fn === "string") fn = [fn];
   let fns = [];
   for (let f of fn) {
     fns.push({"fn": f});
   }
   return new Promise((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    xhr.open("POST", "https://twocansandstring.com/stitchservices");
-    xhr.setRequestHeader("Content-Type", "application/json");
-    xhr.onload = () => {
-      if (xhr.status >= 200 && xhr.status < 300) resolve(JSON.parse(xhr.responseText));
-      else reject({
-        status: xhr.status,
-        statusText: xhr.statusText
-      });
-    };
-    xhr.onerror = () => {
-      reject({
-        status: xhr.status,
-        statusText: xhr.statusText
-      });
-    }
-    xhr.send(JSON.stringify({
-      "apiVersion": null,
-      "expectUserChange": true,
-      "requests": fns
-    }));
-  })
+    fetch("https://twocansandstring.com/stitchservices", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        "apiVersion": null,
+        "expectUserChange": true,
+        "requests": fns
+      })
+    }).then(v => {
+      v.json().then(resolve);
+    }, reject);
+  });
 }
 
 /**

--- a/src/resource/fourth-util.js
+++ b/src/resource/fourth-util.js
@@ -2,7 +2,7 @@
  * Creates a popup window that can be closed. Supports multiple buttons.
  * @param {string} title
  * @param {string} content
- * @param {{ text: string, color?: [string, string], callback: () => void }[]} buttons An array of buttons containing text and functions to run when the button is clicked. For more information view the `fourth` docs.
+ * @param {{ text: string, color?: [string, string], callback: () => any }[]} buttons An array of buttons containing text and functions to run when the button is clicked. For more information view the `fourth` docs.
  */
 fourth.Alert = function(title, content, buttons = []) {
   return new Promise((resolve, reject) => {

--- a/src/resource/fourth-util.js
+++ b/src/resource/fourth-util.js
@@ -1,0 +1,68 @@
+/**
+ * Creates a popup window that can be closed. Supports multiple buttons.
+ * @param {string} title
+ * @param {string} content
+ * @param {{ text: string, color?: [string, string], callback: () => void }[]} buttons An array of buttons containing text and functions to run when the button is clicked. For more information view the `fourth` docs.
+ */
+fourth.Alert = function(title, content, buttons = []) {
+  return new Promise((resolve, reject) => {
+    if (typeof title !== "string" || typeof content !== "string") {
+      reject("Alert popup fields must be a string");
+      return;
+    }
+    const bgEl = document.createElement("div");
+    bgEl.style = "position:fixed;width:100%;height:100vh;top:0;left:0;background:rgba(0,0,0,0.7);";
+    document.body.style.overflow = "hidden" // should be made less brute-forcey
+
+    const alertEl = document.createElement("div");
+    alertEl.style = "position:absolute;height:auto;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;border-radius:8px;";
+    alertEl.innerHTML = `<div style="background:#444;height:auto;color:white;padding:0.5em;border-radius:8px 8px 0 0;word-wrap:break-word;">${title}</div><div style="padding:0.5em;text-align:left;">${content}</div>`;
+
+    const closeEl = document.createElement("a");
+    closeEl.href = "javascript:void(0)";
+    closeEl.innerHTML = "&#10005;";
+    closeEl.style = "font-weight:bold;position:absolute;display:block;top:8.5%;right:5%;color:white;";
+    closeEl.addEventListener("click", () => {
+      bgEl.remove();
+      resolve(false);
+    });
+
+    alertEl.appendChild(closeEl)
+    bgEl.appendChild(alertEl)
+    document.body.append(bgEl);
+
+    if (buttons.length > 0) {
+      for (let button of buttons) {
+        button.color = button.color || ["#0080ff", "#0060e0"]
+        const b = document.createElement("button");
+        b.innerHTML = button.text;
+        b.style.background = `linear-gradient(${button.color.join(", ")})`;
+        b.style.marginRight = "0.25em";
+        b.onclick = () => {
+          bgEl.remove();
+          resolve(button.callback());
+        }
+        alertEl.appendChild(b);
+      }
+    } else {
+      resolve(true);
+    }
+  })
+};
+
+/**
+ * Creates a confirmation window, asking the user to confirm an action and returning `true` if "Yes" is clicked; `false` otherwise.
+ */
+fourth.Confirm = function(title, content) {
+  return fourth.Alert(title, content, [
+    {
+      text: "Yes",
+      callback: () => true
+    },
+    {
+      text: "No",
+      color: ["#a00", "#800"],
+      callback: () => false
+    }
+  ]);
+};

--- a/src/resource/third.js
+++ b/src/resource/third.js
@@ -6,7 +6,7 @@ third.GetEnums = async function() {
 
 /**
  * Returns the path of an injected script (located in the `/injected` directory).
- * @param {string} path 
+ * @param {string} path
  * @returns {string} The full path to the script.
  */
 third.GetPath = function(path) {
@@ -45,7 +45,7 @@ third.InjectFourth = async function(caller) {
 }
 
 /**
- * Inserts a script tag in the page that links to an extension script. 
+ * Inserts a script tag in the page that links to an extension script.
  * If you are calling this function, make sure fourth is injected first with `await third.InjectFourth();`.
  * @param {string} path The path to the script file to be injected. Should be in the `/injected` directory.
  * @param {object} options Additional options.
@@ -58,6 +58,7 @@ third.InjectScript = async function(path, options) {
   el.src = third.GetPath(path);
   el.type = "text/javascript";
   el.async = options.noAsync ? false : true;
+  el.defer = !!options.defer;
   // Why not always use head?
   (options.useHead ? document.head : document.body).append(el);
   return el;

--- a/src/resource/third.js
+++ b/src/resource/third.js
@@ -41,7 +41,8 @@ third.InjectFourth = async function(caller) {
   _inject(caller === "answer" ? "user-id-answer.js" : "user-id-global.js", false);
   _inject("config.js", false);
   _inject("fourth-enums.js", false);
-
+  _inject("fourth-api.js", false);
+  _inject("fourth-util.js", false);
 }
 
 /**
@@ -140,34 +141,5 @@ third.GetUserIDFromAnswerPage = function() {
   const userID = attr.substring(18, attr.length - 1);
   return userID;
 }
-
-/// Doesn't seem necessary for now, if it comes to be needed uncomment and document.
-// /**
-//  * Creates a popup window that can be closed.
-//  * @param {string} title
-//  * @param {string} content
-//  */
-// third.Alert = function(title, content) {
-//   if (typeof title !== "string" || typeof content !== "string") {
-//     console.error("Alert popup fields must be a string");
-//     return;
-//   }
-//   const bgEl = document.createElement("div");
-//   bgEl.style = "position:fixed;width:100%;height:100vh;top:0;left:0;background:rgba(0,0,0,0.7);";
-//   document.body.style = "overflow:hidden;" // should be made less brute-forcey
-//   const alertEl = document.createElement("div");
-//   alertEl.style = "position:absolute;width:30%;height:auto;top:50%;left:50%;transform:translate(-50%,-50%);background:#e0e0e0;border-radius:8px;";
-//   alertEl.innerHTML = `<div style="background:#444;height:auto;color:white;padding:0.5em;border-radius:8px 8px 0 0;word-wrap:break-word;">${title}</div><div style="padding:0.5em;text-align:left;">${content}</div>`;
-//   const closeEl = document.createElement("a");
-//   closeEl.href = "javascript:void(0)";
-//   closeEl.innerHTML = "&#10005;";
-//   closeEl.style = "font-weight:bold;position:absolute;display:block;top:8.5%;right:5%;color:white;";
-//   closeEl.addEventListener("click", () => {
-//     bgEl.remove();
-//   });
-//   alertEl.appendChild(closeEl)
-//   bgEl.appendChild(alertEl)
-//   document.body.append(bgEl);
-// }
 
 export default third;


### PR DESCRIPTION
This adds an option in configuration to restore the way the forum homepage looked before it got modified. In the event that the forum thread pages are archived it might be necessary to take further steps to restore the look as it takes its appearance from the /things/ page. I have the current stylesheets from November 2022 archived, though, so if this does happen it shouldn't be that big of a deal.