### PR TITLE
Added answer page focus features, also slightly improved popup layout & wording

### DIFF
--- a/src/injected/default_settings.json
+++ b/src/injected/default_settings.json
@@ -5,5 +5,6 @@
   "showPronouns": true,
   "displayLatex": true,
   "useHotkeys" : false,
-  "stealAvatar": true
+  "stealAvatar": true,
+  "answerFocus": true
 }

--- a/src/injected/skipForNowButton.js
+++ b/src/injected/skipForNowButton.js
@@ -28,6 +28,9 @@
         // the best way to get a new question would be to reinit the QA
         TC.QA.Answer.init(userID);
         textbox.value = "";
+        if (fourth.config().answerFocus) {
+          textbox.focus();
+        }
       }
     };
   })();

--- a/src/js/answer.js
+++ b/src/js/answer.js
@@ -1,6 +1,20 @@
+function enableRefocus() {
+  document.getElementById("answer_text").focus();
+  let buttons = document.querySelectorAll('#content_host > table > tbody > tr > td:nth-child(2) > div:nth-child(2) > button');
+  for (let button of buttons) {
+    button.addEventListener("click", () => {
+      document.getElementById("answer_text").focus();
+    });
+  }
+}
+
 (async() => {
   const src = browser.runtime.getURL("resource/third.js");
   const third = (await import(src)).default;
+
+  if ((await third.GetSettings()).answerFocus) {
+    enableRefocus();
+  }
 
   third.InjectToggleableScripts({
     useHotkeys: "hotkeys.js",

--- a/src/popup/config.css
+++ b/src/popup/config.css
@@ -2,7 +2,7 @@ body {
   background-color: #2e3440;
   color: #d8dee9;
   font-family: Lato, sans-serif;
-  width: 20em;
+  width: 22em;
 }
 
 #options {

--- a/src/popup/config.html
+++ b/src/popup/config.html
@@ -25,21 +25,20 @@
     <label for="skipForNow">Enable "Skip for now" button</label>
     <br />
     <input id="skipSavedQuestions" type="checkbox" name="skipSavedQuestions">
-    <label for="skipSavedQuestions">Enable skipping saved question button</label>
+    <label for="skipSavedQuestions">Allow removal of saved questions</label>
     <br />
-    <input id="stealAvatar" type="checkbox" name="stealAvatar">
-    <label for="stealAvatar">Enable avatar stealer button</label>
+    <input id="answerFocus" type="checkbox" name="answerFocus">
+    <label for="answerFocus">Improve focus on answer page text box</label>
     <br />
     <input id="useHotkeys" type="checkbox" name="useHotkeys">
     <label for="useHotkeys">Use hotkeys
       <div class="tooltip">
         <i class="fa fa-question-circle" aria-hidden="true"></i>
-        <span class="tooltiptext">
-          Hotkey layout 
+        <div class="tooltiptext">Hotkey layout 
           Ctrl + enter : answer 
           Ctrl + s : save 
           Ctrl + m : skip 
-        </span>
+        </div>
       </div>
      </label>
     <br />
@@ -49,6 +48,9 @@
     <br />
     <input id="displayLatex" type="checkbox" name="displayLatex">
     <label for="displayLatex">Render LaTeX equations in the forum</label>
+    <hr />
+    <input id="stealAvatar" type="checkbox" name="stealAvatar">
+    <label for="stealAvatar">Enable avatar stealer button</label>
     <hr />
     <button id="submit">Save Settings</button>
   </div>

--- a/src/popup/config.js
+++ b/src/popup/config.js
@@ -10,6 +10,7 @@ const tags = {
     "displayLatex",
     "useHotkeys",
     "stealAvatar",
+    "answerFocus",
   ],
   radioTags: [
     "skipConfirm",


### PR DESCRIPTION
Closes #25

Two main things enabled by the new setting:
a. the text box on the answer page is focused on page load
b. the text box is refocused after clicking answer, save, skip, or skip for now

Should be ready for a review; don't imagine it'll take long