### PR TITLE
Add pronouns indicator to user page

### DIFF
--- a/src/js/users.js
+++ b/src/js/users.js
@@ -1,3 +1,21 @@
+function injectPronouns() {
+  const username = window.location.pathname.slice(7);
+  const ea = document.querySelector("#content_host > div > h1");
+  const e = document.createElement("div");
+  e.style.color = "#888";
+  e.style.fontStyle = "italic";
+  fetch("https://novaberman.com/api/thethirdcan/pronouns/" + username).then(r => {
+    if (r.status === 200) {
+      r.text().then(t => {
+        e.textContent = t;
+        ea.after(e);
+      });
+    }
+  }).catch(r => {
+    console.warn("couldn't get pronouns for " + username + "\n\n" + r);
+  });
+}
+
 (async() => {
   const src = browser.runtime.getURL("resource/third.js");
   const third = (await import(src)).default;
@@ -5,4 +23,9 @@
   third.InjectToggleableScripts({
     stealAvatar: "stealAvatarButton.js",
   }, "users");
+
+  const cfg = await third.GetSettings();
+  if (cfg.showPronouns) {
+    injectPronouns();
+  }
 })();


### PR DESCRIPTION
This adds the pronoun indicator from the forum page to the user page. Closes #6.

![image](https://github.com/aprzn123/TheThirdCan/assets/22648124/d50047c4-e572-471c-962e-878f92f19009)
